### PR TITLE
Disables the 'Enter Play Mode Options' feature in Unity's project set…

### DIFF
--- a/ProjectSettings/EditorSettings.asset
+++ b/ProjectSettings/EditorSettings.asset
@@ -24,7 +24,7 @@ EditorSettings:
   m_EnableEditorAsyncCPUTextureLoading: 0
   m_AsyncShaderCompilation: 1
   m_PrefabModeAllowAutoSave: 1
-  m_EnterPlayModeOptionsEnabled: 1
+  m_EnterPlayModeOptionsEnabled: 0
   m_EnterPlayModeOptions: 0
   m_GameObjectNamingDigits: 1
   m_GameObjectNamingScheme: 0


### PR DESCRIPTION
…tings.

This feature was causing an editor-only script to run during play mode, leading to an InvalidOperationException. It also caused stateful issues like looping audio and broken animations due to incomplete scene and domain reloads.

By turning this feature off, we restore the default behavior of a full domain and scene reload when entering play mode, which resolves all reported issues.